### PR TITLE
Align to NuGet MCP conventions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        dotnet-version: ['9.x']
+        dotnet-version: ['10.x']
     env:
       CI: true
     steps:
@@ -63,7 +63,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '9.x'
+          dotnet-version: '10.x'
 
       - name: Extract version
         id: version

--- a/TimeMcpServer.csproj
+++ b/TimeMcpServer.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
+    <RollForward>Major</RollForward>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     
@@ -21,6 +22,7 @@
     <!-- .NET Tool Configuration -->
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>time-mcp-server</ToolCommandName>
+    <PackageType>McpServer</PackageType>
     
   </PropertyGroup>
 
@@ -31,6 +33,7 @@
 
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="server.json" Pack="true" PackagePath="\.mcp\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
We use .NET 10 for improved pack, an `McpServer` package type, and embed the `.mcp/server.json` to enrich the gallery experience.

Also, I added `domdomegg` on NuGet.org to the Trusted Publishing private preview, in case you want to get rid of the fixed API key in `secrets.NUGET_API_KEY`. Docs: https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing.